### PR TITLE
fix: prevent spacebar from starting session when focused on modal but…

### DIFF
--- a/e2e/jazz-chords.spec.ts
+++ b/e2e/jazz-chords.spec.ts
@@ -448,3 +448,76 @@ test('Cancel Button CSS Styling', async ({ page }) => {
   expect(buttonStyles.color).toMatch(/rgb\(255, 255, 255\)|white/);
   expect(buttonStyles.cursor).toBe('pointer');
 });
+
+test('Delete All Data Modal - Spacebar Should Activate Button Not Start Session', async ({ page }) => {
+  await page.goto('http://localhost:3000?arch=refactored');
+  await page.waitForTimeout(2000);
+
+  // Open options menu to access wipe database button
+  const optionsButton = page.locator('#options-button');
+  await optionsButton.click();
+
+  // Click the wipe database button to open modal
+  const wipeDatabaseButton = page.locator('#wipe-database-button');
+  await expect(wipeDatabaseButton).toBeVisible();
+  await wipeDatabaseButton.click();
+
+  // Wait for modal to appear
+  const modal = page.locator('.modal');
+  await expect(modal).toBeVisible();
+
+  // Verify modal content
+  const modalTitle = page.locator('.modal-title');
+  await expect(modalTitle).toHaveText('Delete All Session Data');
+
+  // Find the confirmation input and "Delete All Data" button
+  const confirmationInput = page.locator('#confirmation-input');
+  const deleteAllButton = page.locator('#confirm-wipe-button');
+  
+  await expect(confirmationInput).toBeVisible();
+  await expect(deleteAllButton).toBeVisible();
+  await expect(deleteAllButton).toBeDisabled();
+
+  // Type the confirmation text
+  await confirmationInput.fill('DELETE ALL MY DATA');
+  
+  // Wait for button to become enabled
+  await expect(deleteAllButton).toBeEnabled();
+
+  // Focus the "Delete All Data" button directly
+  await deleteAllButton.focus();
+  
+  // Verify the button is focused
+  await expect(deleteAllButton).toBeFocused();
+
+  // Record the initial state - no session should be running
+  const startButtonLabel = page.locator('#start-stop-button-label');
+  const initialButtonText = await startButtonLabel.textContent();
+  expect(initialButtonText).toBe('Start');
+
+  // Press spacebar while the "Delete All Data" button is focused
+  // This should activate the button (close the modal), NOT start a new session
+  await page.keyboard.press('Space');
+
+  // Wait a moment for any modal closing animation
+  await page.waitForTimeout(500);
+
+  // Verify the modal is closed
+  await expect(modal).not.toBeVisible();
+
+  // Most importantly: verify that pressing spacebar did NOT start a new session
+  // The start button should still say "Start", not "Stop"
+  const finalButtonText = await startButtonLabel.textContent();
+  expect(finalButtonText).toBe('Start');
+
+  // Also verify that no chord problem fields are populated (would indicate session started)
+  const stringSetText = await page.locator('#stringSetTextField').textContent();
+  const rootText = await page.locator('#rootTextField').textContent();
+  const keyText = await page.locator('#keyTextField').textContent();
+  const typeText = await page.locator('#typeTextField').textContent();
+
+  expect(stringSetText).toBe('--');
+  expect(rootText).toBe('--');
+  expect(keyText).toBe('--');
+  expect(typeText).toBe('--');
+});

--- a/public/app.js
+++ b/public/app.js
@@ -391,10 +391,11 @@ function stopTimer() {
 
 function handleSpacebarEvent(event) {
   if (event.keyCode === 32) {
-    // Don't handle spacebar if user is typing in an input or textarea
+    // Don't handle spacebar if user is typing in an input, textarea, or focused on a button
     if (
       event.target.tagName === 'INPUT' ||
-      event.target.tagName === 'TEXTAREA'
+      event.target.tagName === 'TEXTAREA' ||
+      event.target.tagName === 'BUTTON'
     ) {
       return;
     }

--- a/public/app.js
+++ b/public/app.js
@@ -390,7 +390,7 @@ function stopTimer() {
 }
 
 function handleSpacebarEvent(event) {
-  if (event.keyCode === 32) {
+  if (event.code === 'Space') {
     // Don't handle spacebar if user is typing in an input, textarea, or focused on a button
     if (
       event.target.tagName === 'INPUT' ||
@@ -399,7 +399,7 @@ function handleSpacebarEvent(event) {
     ) {
       return;
     }
-    // Check if the pressed key is the spacebar5
+    // Check if the pressed key is the spacebar
     event.preventDefault();
     handleStartButtonClick();
   }

--- a/public/components/UIController.js
+++ b/public/components/UIController.js
@@ -51,8 +51,8 @@ export class UIController {
     // Spacebar for start/stop
     document.addEventListener("keydown", (event) => {
       if (event.code === 'Space') {
-        // Don't handle spacebar if user is typing in an input or textarea
-        if (event.target.tagName === 'INPUT' || event.target.tagName === 'TEXTAREA') {
+        // Don't handle spacebar if user is typing in an input, textarea, or focused on a button
+        if (event.target.tagName === 'INPUT' || event.target.tagName === 'TEXTAREA' || event.target.tagName === 'BUTTON') {
           return;
         }
         event.preventDefault();


### PR DESCRIPTION
…tons

- Update spacebar event handlers in both app.js and UIController.js to exclude BUTTON elements
- Prevents spacebar from incorrectly triggering session start when focused on modal buttons
- Adds E2E test to verify spacebar properly activates focused buttons instead of starting sessions
- Ensures proper keyboard accessibility behavior in Delete All Data modal

🤖 Generated with [Claude Code](https://claude.ai/code)